### PR TITLE
[chorre] Lowercase response headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,35 +114,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Cache turborepo for iOS
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.TURBO_CACHE_DIR }}
-          key: ${{ runner.os }}-turborepo-ios-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-turborepo-ios-
-
-      - name: Check turborepo cache for iOS
-        run: |
-          TURBO_CACHE_STATUS=$(node -p "($(yarn turbo run build:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}" --dry=json)).tasks.find(t => t.task === 'build:ios').cache.status")
-
-          if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
-            echo "turbo_cache_hit=1" >> $GITHUB_ENV
-          fi
-
-      - name: Cache cocoapods
-        if: env.turbo_cache_hit != 1
-        id: cocoapods-cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            **/ios/Pods
-          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cocoapods-
-
       - name: Install cocoapods
-        if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'
         run: |
           cd example/ios
           pod install
@@ -151,4 +123,4 @@ jobs:
 
       - name: Build example for iOS
         run: |
-          yarn turbo run build:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}"
+          yarn turbo run build:ios --no-cache --force

--- a/android/src/main/java/com/pagopa/ioreactnativehttpclient/IoReactNativeHttpClientModule.kt
+++ b/android/src/main/java/com/pagopa/ioreactnativehttpclient/IoReactNativeHttpClientModule.kt
@@ -288,7 +288,7 @@ class IoReactNativeHttpClientModule(reactContext: ReactApplicationContext) :
     val responseHeaders = WritableNativeMap()
     response.headers.forEach { headerName: String, headerValues: List<String> ->
       val joinedValues = headerValues.joinToString()
-      responseHeaders.putString(headerName, joinedValues)
+      responseHeaders.putString(headerName.lowercase(), joinedValues)
     }
 
     val isSuccessHttpStatusCode = responseStatusCode < 400

--- a/ios/IoReactNativeHttpClient.swift
+++ b/ios/IoReactNativeHttpClient.swift
@@ -165,7 +165,7 @@ class IoReactNativeHttpClient: NSObject {
             return;
         }
         let body = response.value ?? ""
-        let headers = response.response?.headers.dictionary ?? [:]
+        let headers = toLowerCaseHeaders(response.response?.headers)
         
         let httpResponse: [String: Any] = statusCode < 400 ? [
             "type": "success",
@@ -179,6 +179,17 @@ class IoReactNativeHttpClient: NSObject {
             "headers": headers
         ]
         resolve(httpResponse)
+    }
+    
+    func toLowerCaseHeaders(_ headersOpt: HTTPHeaders?) -> [String: String] {
+        if var headersDictionary = headersOpt?.dictionary {
+            let caseSensitiveKeys = headersDictionary.keys
+            for key in caseSensitiveKeys {
+                headersDictionary[key.lowercased()] = headersDictionary.removeValue(forKey: key)
+            }
+            return headersDictionary
+        }
+        return [:]
     }
     
     func handleNonHttpFailure(_ message: String, resolve: @escaping RCTPromiseResolveBlock) -> Void {


### PR DESCRIPTION
## Short description
This PR forces response headers' names to always be lowercase (invariant locale)

## List of changes proposed in this pull request
- On iOS, headers are stored into a dictionary. Values are removed and added with a lowercase key
- On Android, headers are saved into a writable map with a lowercase key

## How to test
Make an HTTP call that returns headers and check that names are all lowercase
