### PR TITLE
[IOCOM-1577] Support for empty body serialisation and error handling

### DIFF
--- a/android/src/main/java/com/pagopa/ioreactnativehttpclient/IoReactNativeHttpClientModule.kt
+++ b/android/src/main/java/com/pagopa/ioreactnativehttpclient/IoReactNativeHttpClientModule.kt
@@ -31,6 +31,7 @@ import io.ktor.http.Url
 import io.ktor.util.StringValues
 import io.ktor.util.StringValuesBuilderImpl
 import io.ktor.util.date.GMTDate
+import io.ktor.utils.io.charsets.MalformedInputException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -294,6 +295,7 @@ class IoReactNativeHttpClientModule(reactContext: ReactApplicationContext) :
       is HttpRequestTimeoutException, is ConnectTimeoutException, is SocketTimeoutException -> "Timeout"
       is CancellationException -> "Cancelled"
       is SSLHandshakeException -> "TLS Failure"
+      is MalformedInputException -> "Serialization Failure"
       else -> e.message ?: "Unable to send network request, unknown error"
     }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -76,7 +76,7 @@ PODS:
   - hermes-engine/Pre-built (0.72.14)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
-  - pagopa-io-react-native-http-client (1.0.2):
+  - pagopa-io-react-native-http-client (1.0.4):
     - Alamofire (~> 5.9.1)
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
@@ -681,7 +681,7 @@ SPEC CHECKSUMS:
   hermes-engine: b213bace5f31766ad1434d2d9b2cbf04cf92a2b6
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  pagopa-io-react-native-http-client: 48d51868a2751db4d9220283626d0d53f2375f63
+  pagopa-io-react-native-http-client: cd756d9e56b783a8bf1429fc9ae65b32e75be929
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 264adaca1d8b1a9c078761891898d4142df05313
   RCTTypeSafety: 279a89da7058a69899778a127be73fab38b84499

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,6 +48,7 @@ export const deallocate = (): void => IoReactNativeHttpClient.deallocate();
 
 export const NonHttpErrorCode = 900;
 export const CancelledMessage = 'Cancelled';
+export const SerializationFailure = 'Serialization Failure';
 export const TimeoutMessage = 'Timeout';
 export const TLSMessage = 'TLS Failure';
 
@@ -65,6 +66,13 @@ export const isCancelledFailure = (
   isFailureResponse(response) &&
   response.code === NonHttpErrorCode &&
   response.message === CancelledMessage;
+
+export const isSerializationFailure = (
+  response: HttpClientResponse
+): response is HttpClientFailureResponse =>
+  isFailureResponse(response) &&
+  response.code === NonHttpErrorCode &&
+  response.message === SerializationFailure;
 
 export const isTimeoutFailure = (
   response: HttpClientResponse


### PR DESCRIPTION
## Short description
This PR adds native support for empty body serialisation and serialisation error detection

## List of changes proposed in this pull request
- iOS support for empty body serialisation
- iOS explicit detection of serialisation error
- Android explicit detection of serialisation error

## How to test
Make a call to something that responds with a successful empty body and check that the output is a success response.
Make a call to something that responds with an invalid string content (like an image) and check that the reported error is a `Serialisation Failure`
