### PR TITLE
chore: [IOPID-3868] Restore original `release-it` behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typecheck": "tsc",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "test": "jest",
-    "release": "release-it --only-version"
+    "release": "release-it"
   },
   "keywords": [
     "react-native",
@@ -151,7 +151,8 @@
       "@release-it/conventional-changelog": {
         "preset": {
           "name": "angular"
-        }
+        },
+        "ignoreRecommendedBump": true
       }
     }
   },


### PR DESCRIPTION
## Short description
This PR restores the `release-it` command's behaviour (see list of changes)

## List of changes proposed in this pull request
- Removed the `--only-version` flag that was only making a versioning commit and not triggering the release mechanism
- Added the `"ignoreRecommendedBump": true` setting so that the `release-it` command always ask which version to bump

## How to test
CI should succeed
